### PR TITLE
LoadBuildTools on InstallAndTestModule for Get-SpecialPaths function

### DIFF
--- a/plaster/ModuleBuild/scaffold/modulename.build.template
+++ b/plaster/ModuleBuild/scaffold/modulename.build.template
@@ -883,7 +883,7 @@ task GithubPush VersionCheck, {
 task . Configure, CodeHealthReport, Clean, PrepareStage, GetPublicFunctions, SanitizeCode, CreateHelp, CreateModulePSM1, CreateModuleManifest, AnalyzeModuleRelease, PushVersionRelease, PushCurrentRelease, CreateProjectHelp, PostBuildTasks, BuildSessionCleanup
 
 # Synopsis: Install and test load the module.
-task InstallAndTestModule InstallModule, TestInstalledModule
+task InstallAndTestModule LoadBuildTools, InstallModule, TestInstalledModule
 
 # Synopsis: Build, Install, and Test the module
 task BuildInstallAndTestModule Configure, CodeHealthReport, Clean, PrepareStage, GetPublicFunctions, SanitizeCode, CreateHelp, CreateModulePSM1, CreateModuleManifest, AnalyzeModuleRelease, PushVersionRelease, PushCurrentRelease, CreateProjectHelp, InstallModule, TestInstalledModule, PostBuildTasks, BuildSessionCleanup
@@ -891,5 +891,5 @@ task BuildInstallAndTestModule Configure, CodeHealthReport, Clean, PrepareStage,
 # Synopsis: Build, Install, Test, and Publish the module
 task BuildInstallTestAndPublishModule Configure, CodeHealthReport, Clean, PrepareStage, GetPublicFunctions, SanitizeCode, CreateHelp, CreateModulePSM1, CreateModuleManifest, AnalyzeModuleRelease, PushVersionRelease, PushCurrentRelease, CreateProjectHelp, InstallModule, TestInstalledModule, PublishPSGallery, PostBuildTasks, BuildSessionCleanup
 
-# Synopsis: Instert Comment Based Help where it doesn't already exist (output to scratch directory)
+# Synopsis: Insert Comment Based Help where it doesn't already exist (output to scratch directory)
 task InsertMissingCBH Configure, Clean, UpdateCBHtoScratch, BuildSessionCleanup


### PR DESCRIPTION
LoadBuildTools is not called on InstallAndTestModule, this causes the task to fail since it needs Get-SpecialPaths.

```Powershell
$MyModulePath = "$((Get-SpecialPaths)['MyDocuments'])\WindowsPowerShell\Modules\"
```

```Powershell
.\Build.ps1 -InstallAndTestModule
Build InstallAndTestModule C:\SomePath\SomeModule\build\SomeModule.buildenvironment.ps1
Task /InstallAndTestModule/InstallModule/VersionCheck/LoadModuleManifest
* Loading the existing module manifest for this module
Done /InstallAndTestModule/InstallModule/VersionCheck/LoadModuleManifest 00:00:00.0040112
Task /InstallAndTestModule/InstallModule/VersionCheck
* Validating manifest, build, and gallery module versions.
  Manifest version and the release version in the build configuration file are the same.
  This module has not been published to the gallery so any version is ok to build at this point.
Done /InstallAndTestModule/InstallModule/VersionCheck 00:00:02.1536004
Task /InstallAndTestModule/InstallModule
* Attempting to install the current module
ERROR: The term 'Get-SpecialPaths' is not recognized as the name of a cmdlet, function, script file, or operable program. Check the spelling of the name, or if a path was included, verify that the path is correct and try again.
At C:\SomePath\SomeModule\build\SomeModule.build.ps1:790 char:25
+     $MyModulePath = "$((Get-SpecialPaths)['Personal'])\WindowsPowerSh ...
+                         ~~~~~~~~~~~~~~~~
AC:\SomePath\SomeModule\build\SomeModule.build.ps1:785 char:1
+ task InstallModule VersionCheck, {
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
At C:\SomePath\SomeModule\build\SomeModule.build.ps1:893 char:1
+ task InstallAndTestModule InstallModule, TestInstalledModule
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Build FAILED. 4 tasks, 1 errors, 0 warnings 00:00:02.6679850
Install and test of module failed:
Get-SpecialPaths : The term 'Get-SpecialPaths' is not recognized as the name of a cmdlet, function, script file, or operable program. Check the spelling of the name, or if a path was included, verify that the path is correct and try again.
At C:\SomePath\SomeModule\build\SomeModule.build.ps1:790 char:25
+     $MyModulePath = "$((Get-SpecialPaths)['Personal'])\WindowsPowerSh ...
+                         ~~~~~~~~~~~~~~~~
    + CategoryInfo          : ObjectNotFound: (Get-SpecialPaths:String) [], CommandNotFoundException
    + FullyQualifiedErrorId : CommandNotFoundException


Attempting to clean up the session (loaded modules and such)...
Build BuildSessionCleanup C:\SomePath\SomeModule\build\SomeModule.buildenvironment.ps1
Task /BuildSessionCleanup/LoadRequiredModules
* Loading all required modules for the build framework
  Importing PlatyPS Module
  Importing PSScriptAnalyzer Module
  Importing Powershell-YAML Module
Done /BuildSessionCleanup/LoadRequiredModules 00:00:00.6878273
Task /BuildSessionCleanup
* Cleaning up the build session
  Removing modules
   Removing PlatyPS module (if loaded).
   Removing PSScriptAnalyzer module (if loaded).
   Removing Powershell-YAML module (if loaded).
   Removing PSSpamTitan module (if loaded).
Done /BuildSessionCleanup 00:00:00.7254182
Build succeeded. 2 tasks, 0 errors, 0 warnings 00:00:00.7790586
```

Fixed by adding `LoadBuildTools` to the `InstallAndTestModule` task.

```Powershell
# Synopsis: Install and test load the module.
task InstallAndTestModule LoadBuildTools, InstallModule, TestInstalledModule
```

```powershell
PS C:\temp\testtesttest> .\build -InstallAndTestModule
Build InstallAndTestModule C:\SomePath\SomeModule\build\SomeModule.buildenvironment.ps1
Task /InstallAndTestModule/LoadBuildTools
* Sourcing all of the required build functions
  Dot sourcing script file: Convert-ArrayToString.ps1
  Dot sourcing script file: Convert-HashToString.ps1
  Dot sourcing script file: Get-BuildEnvironment.ps1
  Dot sourcing script file: Get-ErrorDetail.ps1
  Dot sourcing script file: Get-ErrorInfo.ps1
  Dot sourcing script file: Get-SpecialPaths.ps1
  Dot sourcing script file: New-CommentBasedHelp.ps1
  Dot sourcing script file: New-DynamicParameter.ps1
  Dot sourcing script file: New-PSGalleryProjectProfile.ps1
  Dot sourcing script file: Out-Zip.ps1
  Dot sourcing script file: Out-ZipFromFile.ps1
  Dot sourcing script file: Prompt-ForBuildBreak.ps1
  Dot sourcing script file: Remove-Signature.ps1
  Dot sourcing script file: Replace-FileString.ps1
  Dot sourcing script file: Set-BuildEnvironment.ps1
  Dot sourcing script file: Upload-ProjectToPSGallery.ps1
Done /InstallAndTestModule/LoadBuildTools 00:00:00.3980541
Task /InstallAndTestModule/InstallModule/VersionCheck/LoadModuleManifest
* Loading the existing module manifest for this module
Done /InstallAndTestModule/InstallModule/VersionCheck/LoadModuleManifest 00:00:00.0416106
Task /InstallAndTestModule/InstallModule/VersionCheck
* Validating manifest, build, and gallery module versions.
  Manifest version and the release version in the build configuration file are the same.
````