### PR TITLE
Add PSScriptAnalyzerSettings.psd1 file

### DIFF
--- a/ModuleBuild.build.ps1
+++ b/ModuleBuild.build.ps1
@@ -462,31 +462,25 @@ task UpdateCBH {
 task AnalyzeModuleRelease -if {$Script:BuildEnv.OptionAnalyzeCode} {
     Write-Description White 'Analyzing the project with ScriptAnalyzer' -accent
     $StageReleasePath = Join-Path (Join-Path $BuildRoot $Script:BuildEnv.ScratchFolder) $Script:BuildEnv.BaseReleaseFolder
-    $Analysis = Invoke-ScriptAnalyzer -Path $StageReleasePath
-    $AnalysisErrors = @($Analysis | Where-Object {@('Information', 'Warning') -notcontains $_.Severity})
-    if ($AnalysisErrors.Count -ne 0) {
-        Write-Build White 'The following errors came up in the script analysis:' -level 2
-        $AnalysisErrors
-        Write-Build
-        Write-Build White "Note that this was from the script analysis run against $StageReleasePath" -Level 2
-        Prompt-ForBuildBreak -CustomError $AnalysisErrors
+    $Analysis = Invoke-ScriptAnalyzer -Path $StageReleasePath -Settings (Join-Path $BuildRoot "PSScriptAnalyzerSettings.psd1")
+    if ($Analysis.Count) {
+        Write-Description White "Note that this was from the script analysis run against $StageReleasePath" -level 2
+        Write-Description Red "$($Analysis.Count) linting errors or warnings were found:" -level 2
+        $Analysis | Format-Table -AutoSize
+        Write-Error "$($Analysis.Count) linting errors or warnings were found. The build cannot continue." -ErrorAction Stop
     }
 }
 
 # Synopsis: Run PSScriptAnalyzer against the public source files.
 task AnalyzePublic {
-    Write-Description White 'Analyzing the public source files with ScriptAnalyzer.' -accent
-    $Analysis = Invoke-ScriptAnalyzer -Path (Join-Path $BuildRoot $Script:BuildEnv.PublicFunctionSource)
-    $AnalysisErrors = @($Analysis | Where-Object {@('Information', 'Warning') -notcontains $_.Severity})
-
-    if ($AnalysisErrors.Count -ne 0) {
-        Write-Description White 'The following errors came up in the script analysis:' -level 2
-        $AnalysisErrors
-        Write-Description
+    Write-Description White "Analyzing the public source files with ScriptAnalyzer." -accent
+    $Analysis = Invoke-ScriptAnalyzer -Path (Join-Path $BuildRoot $Script:BuildEnv.PublicFunctionSource) -Settings (Join-Path $BuildRoot "PSScriptAnalyzerSettings.psd1")
+    if ($Analysis.Count) {
         Write-Description White "Note that this was from the script analysis run against $($Script:BuildEnv.PublicFunctionSource)" -level 2
+        Write-Description Red "$($Analysis.Count) linting errors or warnings were found:" -level 2
+        $Analysis | Format-Table -AutoSize
     }
 }
-
 # Synopsis: Build help files for module
 task CreateHelp CreateMarkdownHelp, CreateExternalHelp, CreateUpdateableHelpCAB, CreateProjectHelp, AddAdditionalDocFiles
 

--- a/PSScriptAnalyzerSettings.psd1
+++ b/PSScriptAnalyzerSettings.psd1
@@ -1,0 +1,4 @@
+@{
+    IncludeRules=@('PSProvideCommentHelp',
+                   'PSAvoidUsingWriteHost')
+}

--- a/plaster/ModuleBuild/plasterManifest.xml
+++ b/plaster/ModuleBuild/plasterManifest.xml
@@ -4,7 +4,7 @@
   templateType="Project" xmlns="http://www.microsoft.com/schemas/PowerShell/Plaster/v1">
   <metadata>
     <name>ModuleBuild</name>
-    <id>c0ce518c-f894-4114-91f9-d49945d9dfb1</id>
+    <id>4b283342-b625-4db2-99c7-cf85de213289</id>
     <version>0.0.1</version>
     <title>New ModuleBuild Project</title>
     <description>Create a new PowerShell Module with a ModuleBuild wrapper</description>
@@ -194,7 +194,19 @@
       condition="$PLASTER_PARAM_PluginModuleLogging -eq &quot;True&quot;" />
     <file
       source="scaffold\plugins\NLog\NLogModule\*"
-      destination="plugins\nlog\NLog\NLogModule"
+      destination="plugins\nlog\NLogModule"
+      condition="$PLASTER_PARAM_PluginModuleLogging -eq &quot;True&quot;" />
+    <file
+      source="scaffold\plugins\NLog\NLogModule\docs\*"
+      destination="plugins\nlog\NLogModule\docs"
+      condition="$PLASTER_PARAM_PluginModuleLogging -eq &quot;True&quot;" />
+    <file
+      source="scaffold\plugins\NLog\NLogModule\en-US\*"
+      destination="plugins\nlog\NLogModule\en-US"
+      condition="$PLASTER_PARAM_PluginModuleLogging -eq &quot;True&quot;" />
+    <file
+      source="scaffold\plugins\NLog\NLogModule\lib\*"
+      destination="plugins\nlog\NLogModule\lib"
       condition="$PLASTER_PARAM_PluginModuleLogging -eq &quot;True&quot;" />
     <file
       source="scaffold\build\cleanup\*"
@@ -257,5 +269,8 @@
     <templateFile
       source="scaffold\build\docs\ReadTheDocs\*"
       destination="build\docs\ReadTheDocs" />
+    <file
+      source="scaffold\PSScriptAnalyzerSettings.psd1"
+      destination="PSScriptAnalyzerSettings.psd1" />
   </content>
 </plasterManifest>

--- a/plaster/ModuleBuild/scaffold/PSScriptAnalyzerSettings.psd1
+++ b/plaster/ModuleBuild/scaffold/PSScriptAnalyzerSettings.psd1
@@ -1,0 +1,26 @@
+@{
+    IncludeRules=@('PSUseApprovedVerbs',
+                   'PSReservedCmdletChar',
+                   'PSReservedParams',
+                   'PSShouldProcess',
+                   'PSUseShouldProcessForStateChangingFunctions',
+                   'PSUseSingularNouns',
+                   'PSMissingModuleManifestField',
+                   'PSAvoidDefaultValueSwitchParameter',
+                   'PSAvoidUsingCmdletAliases',
+                   'PSAvoidUsingWMICmdlet',
+                   'PSAvoidUsingEmptyCatchBlock',
+                   'PSUseCmdletCorrectly',
+                   'PSUseShouldProcessForStateChangingFunctions',
+                   'PSAvoidUsingPositionalParameters',
+                   'PSAvoidGlobalVars',
+                   'PSUseDeclaredVarsMoreThanAssignments',
+                   'PSAvoidUsingInvokeExpression',
+                   'PSAvoidUsingPlainTextForPassword',
+                   'PSAvoidUsingComputerNameHardcoded',
+                   'PSAvoidUsingConvertToSecureStringWithPlainText',
+                   'PSUsePSCredentialType',
+                   'PSAvoidUsingUserNameAndPasswordParams',
+                   'PSDSC*'
+                   )
+}

--- a/plaster/ModuleBuild/scaffold/modulename.build.template
+++ b/plaster/ModuleBuild/scaffold/modulename.build.template
@@ -465,28 +465,23 @@ task UpdateCBH {
 task AnalyzeModuleRelease -if {$Script:BuildEnv.OptionAnalyzeCode} {
     Write-Description White 'Analyzing the project with ScriptAnalyzer' -accent
     $StageReleasePath = Join-Path (Join-Path $BuildRoot $Script:BuildEnv.ScratchFolder) $Script:BuildEnv.BaseReleaseFolder
-    $Analysis = Invoke-ScriptAnalyzer -Path $StageReleasePath
-    $AnalysisErrors = @($Analysis | Where-Object {@('Information', 'Warning') -notcontains $_.Severity})
-    if ($AnalysisErrors.Count -ne 0) {
-        Write-Build White 'The following errors came up in the script analysis:' -level 2
-        $AnalysisErrors
-        Write-Build
-        Write-Build White "Note that this was from the script analysis run against $StageReleasePath" -Level 2
-        Prompt-ForBuildBreak -CustomError $AnalysisErrors
+    $Analysis = Invoke-ScriptAnalyzer -Path $StageReleasePath -Settings (Join-Path $BuildRoot "PSScriptAnalyzerSettings.psd1")
+    if ($Analysis.Count) {
+        Write-Description White "Note that this was from the script analysis run against $StageReleasePath" -level 2
+        Write-Description Red "$($Analysis.Count) linting errors or warnings were found:" -level 2
+        $Analysis | Format-Table -AutoSize
+        Write-Error "$($Analysis.Count) linting errors or warnings were found. The build cannot continue." -ErrorAction Stop
     }
 }
 
 # Synopsis: Run PSScriptAnalyzer against the public source files.
 task AnalyzePublic {
-    Write-Description White 'Analyzing the public source files with ScriptAnalyzer.' -accent
-    $Analysis = Invoke-ScriptAnalyzer -Path (Join-Path $BuildRoot $Script:BuildEnv.PublicFunctionSource)
-    $AnalysisErrors = @($Analysis | Where-Object {@('Information', 'Warning') -notcontains $_.Severity})
-
-    if ($AnalysisErrors.Count -ne 0) {
-        Write-Description White 'The following errors came up in the script analysis:' -level 2
-        $AnalysisErrors
-        Write-Description
+    Write-Description White "Analyzing the public source files with ScriptAnalyzer." -accent
+    $Analysis = Invoke-ScriptAnalyzer -Path (Join-Path $BuildRoot $Script:BuildEnv.PublicFunctionSource) -Settings (Join-Path $BuildRoot "PSScriptAnalyzerSettings.psd1")
+    if ($Analysis.Count) {
         Write-Description White "Note that this was from the script analysis run against $($Script:BuildEnv.PublicFunctionSource)" -level 2
+        Write-Description Red "$($Analysis.Count) linting errors or warnings were found:" -level 2
+        $Analysis | Format-Table -AutoSize
     }
 }
 
@@ -883,7 +878,7 @@ task GithubPush VersionCheck, {
 task . Configure, CodeHealthReport, Clean, PrepareStage, GetPublicFunctions, SanitizeCode, CreateHelp, CreateModulePSM1, CreateModuleManifest, AnalyzeModuleRelease, PushVersionRelease, PushCurrentRelease, CreateProjectHelp, PostBuildTasks, BuildSessionCleanup
 
 # Synopsis: Install and test load the module.
-task InstallAndTestModule LoadBuildTools, InstallModule, TestInstalledModule
+task InstallAndTestModule InstallModule, TestInstalledModule
 
 # Synopsis: Build, Install, and Test the module
 task BuildInstallAndTestModule Configure, CodeHealthReport, Clean, PrepareStage, GetPublicFunctions, SanitizeCode, CreateHelp, CreateModulePSM1, CreateModuleManifest, AnalyzeModuleRelease, PushVersionRelease, PushCurrentRelease, CreateProjectHelp, InstallModule, TestInstalledModule, PostBuildTasks, BuildSessionCleanup
@@ -891,5 +886,5 @@ task BuildInstallAndTestModule Configure, CodeHealthReport, Clean, PrepareStage,
 # Synopsis: Build, Install, Test, and Publish the module
 task BuildInstallTestAndPublishModule Configure, CodeHealthReport, Clean, PrepareStage, GetPublicFunctions, SanitizeCode, CreateHelp, CreateModulePSM1, CreateModuleManifest, AnalyzeModuleRelease, PushVersionRelease, PushCurrentRelease, CreateProjectHelp, InstallModule, TestInstalledModule, PublishPSGallery, PostBuildTasks, BuildSessionCleanup
 
-# Synopsis: Insert Comment Based Help where it doesn't already exist (output to scratch directory)
+# Synopsis: Instert Comment Based Help where it doesn't already exist (output to scratch directory)
 task InsertMissingCBH Configure, Clean, UpdateCBHtoScratch, BuildSessionCleanup

--- a/plaster/ModuleBuild/scaffold/src/other/PostLoad.ps1
+++ b/plaster/ModuleBuild/scaffold/src/other/PostLoad.ps1
@@ -53,7 +53,9 @@ $null = Register-EngineEvent -SourceIdentifier ( [System.Management.Automation.P
 }
 
 # Use this in your scripts to check if the function is being called from your module or independantly.
+# Call it immediately to avoid PSScriptAnalyzer 'PSUseDeclaredVarsMoreThanAssignments'
 $ThisModuleLoaded = $true
+$ThisModuleLoaded
 
 # Non-function exported public module members might go here.
 #Export-ModuleMember -Variable SomeVariable -Function  *

--- a/plaster/PlasterContent.ps1
+++ b/plaster/PlasterContent.ps1
@@ -26,7 +26,7 @@ $Content = @(
         ContentType = 'file'
         Source = 'scaffold\gitattributes'
         Destination = '.gitattributes'
-    },
+    },   
     @{
         ContentType = 'templateFile'
         Source = 'scaffold\vscode\*'
@@ -190,5 +190,10 @@ $Content = @(
         ContentType = 'templateFile'
         Source = 'scaffold\build\docs\ReadTheDocs\*'
         Destination = 'build\docs\ReadTheDocs'
+    },
+    @{
+        ContentType = 'file'
+        Source = 'scaffold\PSScriptAnalyzerSettings.psd1'
+        Destination = 'PSScriptAnalyzerSettings.psd1'
     }
 )

--- a/src/other/PostLoad.ps1
+++ b/src/other/PostLoad.ps1
@@ -54,7 +54,9 @@ $null = Register-EngineEvent -SourceIdentifier ( [System.Management.Automation.P
 }
 
 # Use this in your scripts to check if the function is being called from your module or independantly.
+# Call it immediately to avoid PSScriptAnalyzer 'PSUseDeclaredVarsMoreThanAssignments'
 $ThisModuleLoaded = $true
+$ThisModuleLoaded
 
 # Non-function exported public module members might go here.
 #Export-ModuleMember -Variable SomeVariable -Function  *


### PR DESCRIPTION
ModuleBuild uses the default PSScriptAnalyzerSettings settings.  
In order to change this you could edit the build script for every project you create using ModuleBuild. 
Using a standalone file with PSScriptAnalyzerSettings settings seemed like a better idea to me. 

By default, ModuleBuild creates a `PSScriptAnalyzerSettings.psd1` file with the `PSGallery` preset.

To avoid PostLoad.ps1 causing a `PSUseDeclaredVarsMoreThanAssignments` `$ThisModuleLoaded` is now immediately called after defining it. 

Updated the `AnalyzeModuleRelease` and `AnalyzePublic` tasks. 

- Results are now shown (`$Analysis | Format-Table -AutoSize`). 
- When using the `AnalyzeModuleRelease` task, if PSScriptAnalyzerSettings finds something according to the ruleset defined in `PSScriptAnalyzerSettings.psd1` the build now **fails**.