### PR TITLE
VSCode should use the included PSScriptAnalyzerSettings.psd1

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,5 +13,5 @@
 
     // Use a custom PowerShell Script Analyzer settings file for this workspace.
     // Relative paths for this setting are always relative to the workspace root dir.
-    "powershell.scriptAnalysis.settingsPath": "ScriptAnalyzerSettings.psd1"
+    "powershell.scriptAnalysis.settingsPath": "PSScriptAnalyzerSettings.psd1"
 }

--- a/plaster/ModuleBuild/scaffold/vscode/settings.json
+++ b/plaster/ModuleBuild/scaffold/vscode/settings.json
@@ -15,15 +15,15 @@
     // based on the file contents when `editor.detectIndentation` is true.
     "editor.tabSize": 4,
     // Insert spaces when pressing Tab. This setting is overriden
-    // based on the file contents when `editor.detectIndentation` is true.   
+    // based on the file contents when `editor.detectIndentation` is true.
     "editor.insertSpaces": true,
     // When opening a file, `editor.tabSize` and `editor.insertSpaces`
     // will be detected based on the file contents. Set to false to keep
-    // the values you've explicitly set, above.    
+    // the values you've explicitly set, above.
     "editor.detectIndentation": false,
     //-------- PowerShell Configuration --------
 
     // Use a custom PowerShell Script Analyzer settings file for this workspace.
     // Relative paths for this setting are always relative to the workspace root dir.
-    "powershell.scriptAnalysis.settingsPath": "ScriptAnalyzerSettings.psd1"
+    "powershell.scriptAnalysis.settingsPath": "PSScriptAnalyzerSettings.psd1"
 }


### PR DESCRIPTION
Since 2403aff399bda0b61b6512e46397dd2f592f8508 now ensures there is a PSScriptAnalyzerSettings.psd1 file in the module stucture I think its a good idea to make VSCode use it by default.